### PR TITLE
Fix typo in heatmap.R

### DIFF
--- a/workflow/scripts/heatmap.R
+++ b/workflow/scripts/heatmap.R
@@ -49,7 +49,7 @@ if (feature_list_name=="FILTERED"){
 # if no features in the results, end early with empty plot
 if(length(feature_list)==0){
     ggsave_new(filename = feature_list_name, 
-           results_path=dirname(lfc_heatmap_path), 
+           results_path=dirname(dea_lfc_heatmap_path), 
            plot = ggplot() + annotate("text", x = 0.5, y = 0.5, label = "Features not found in DEA results.") + theme_void(), 
            width=4, 
            height=1)


### PR DESCRIPTION
lfc_heatmap_path is not defined. Should be dea_lfc_heatmap_path.

https://github.com/epigen/dea_limma/blob/175762af36549fda100e7af726581ee2213834a0/workflow/scripts/heatmap.R#L52

Might not have been caught earlier as only happens when there are no features (`# if no features in the results, end early with empty plot`).